### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/public/bibtex/publications.bib
+++ b/public/bibtex/publications.bib
@@ -15,7 +15,7 @@
 	journal = {Computer Applications in Engineering Education},
 	year         = 2018,
 	issn = {1099-0542},
-	url = {http://dx.doi.org/10.1002/cae.21907},
+	url = {https://doi.org/10.1002/cae.21907},
 	doi = {10.1002/cae.21907},
 	pages = {n/a--n/a},
 	keywords = {educational tool, experimental design, generating examples, multifactorial model, problem-based learning},
@@ -58,7 +58,7 @@
 	year = "2016",
 	note = "12th IFAC Workshop on Intelligent Manufacturing Systems IMS 2016Austin, Texas, USA, 5—7 December 2016 ",
 	issn = "2405-8963",
-	doi = "http://dx.doi.org/10.1016/j.ifacol.2016.12.175",
+	doi = "https://doi.org/10.1016/j.ifacol.2016.12.175",
 	url = "http://www.sciencedirect.com/science/article/pii/S2405896316328464",
 	author = "V. Azhmyakov and J.P. Fernández-Gutiérrez and S.K. Gadi and St. Pickl",
 	abstract = "Abstract: This paper deals with the Maximal Covering Location Problem (MCLP) for Supply Chain optimization in the presence of incomplete information. A specific linear-integer structure of a generic mathematical model for Resilient Supply Chain Management System (RSCMS) makes it possible to reduce the originally given \{MCLP\} to two auxiliary optimization Knapsack-type problems. The equivalent transformation (separation) we propose provides a useful tool for an effective numerical treatment of the original \{MCLP\} and reduces the complexity of algorithms. The computational methodology we follow involves a specific Lagrange relaxation procedure. We give a rigorous formal analysis of the resulting algorithm and apply it to a practically oriented example of an optimal \{RSCMS\} design. "
@@ -100,7 +100,7 @@
 	abstract="This paper presents a stability analysis of the interaction between a human and a linear moving Force Augmenting Device (FAD). The analysis employs a mathematical model of the human arm, the FAD and their interaction. As a depart from past works, this article presents a stability analysis considering time-delays in the human model. A key ingredient in the analysis is the use of the Rekasius substitution for replacing the time-delay terms. It is proved that the human machine interaction is stable when the human model has no delays. When delays are considered in the human model, the analysis provides an upper bound for the time-delays preserving a stable interaction. Numerical simulations allow to assess the human-FAD interaction. An experiment is performed with a laboratory prototype, where a human operator lifts a load. It is observed that the human machine interaction is stable and the human operator is able to move the load to a desired position by experiencing very little effort.",
 	issn="1573-0409",
 	doi="10.1007/s10846-016-0420-6",
-	url="http://dx.doi.org/10.1007/s10846-016-0420-6",
+	url="https://doi.org/10.1007/s10846-016-0420-6",
 	month=sep
 }
 

--- a/public/js/script001.js
+++ b/public/js/script001.js
@@ -17,7 +17,7 @@ function OpenDOI(DOI) {
 	if (isUrlValid($(DOI).text()))
 		window.open($(DOI).text(), '_blank');
 	else
-		window.open('http://dx.doi.org/' + $(DOI).text(), '_blank');
+		window.open('https://doi.org/' + $(DOI).text(), '_blank');
 }
 
 function OpenURL(URL) {

--- a/static/bibtex/publications.bib
+++ b/static/bibtex/publications.bib
@@ -15,7 +15,7 @@
 	journal = {Computer Applications in Engineering Education},
 	year         = 2018,
 	issn = {1099-0542},
-	url = {http://dx.doi.org/10.1002/cae.21907},
+	url = {https://doi.org/10.1002/cae.21907},
 	doi = {10.1002/cae.21907},
 	pages = {n/a--n/a},
 	keywords = {educational tool, experimental design, generating examples, multifactorial model, problem-based learning},
@@ -58,7 +58,7 @@
 	year = "2016",
 	note = "12th IFAC Workshop on Intelligent Manufacturing Systems IMS 2016Austin, Texas, USA, 5—7 December 2016 ",
 	issn = "2405-8963",
-	doi = "http://dx.doi.org/10.1016/j.ifacol.2016.12.175",
+	doi = "https://doi.org/10.1016/j.ifacol.2016.12.175",
 	url = "http://www.sciencedirect.com/science/article/pii/S2405896316328464",
 	author = "V. Azhmyakov and J.P. Fernández-Gutiérrez and S.K. Gadi and St. Pickl",
 	abstract = "Abstract: This paper deals with the Maximal Covering Location Problem (MCLP) for Supply Chain optimization in the presence of incomplete information. A specific linear-integer structure of a generic mathematical model for Resilient Supply Chain Management System (RSCMS) makes it possible to reduce the originally given \{MCLP\} to two auxiliary optimization Knapsack-type problems. The equivalent transformation (separation) we propose provides a useful tool for an effective numerical treatment of the original \{MCLP\} and reduces the complexity of algorithms. The computational methodology we follow involves a specific Lagrange relaxation procedure. We give a rigorous formal analysis of the resulting algorithm and apply it to a practically oriented example of an optimal \{RSCMS\} design. "
@@ -100,7 +100,7 @@
 	abstract="This paper presents a stability analysis of the interaction between a human and a linear moving Force Augmenting Device (FAD). The analysis employs a mathematical model of the human arm, the FAD and their interaction. As a depart from past works, this article presents a stability analysis considering time-delays in the human model. A key ingredient in the analysis is the use of the Rekasius substitution for replacing the time-delay terms. It is proved that the human machine interaction is stable when the human model has no delays. When delays are considered in the human model, the analysis provides an upper bound for the time-delays preserving a stable interaction. Numerical simulations allow to assess the human-FAD interaction. An experiment is performed with a laboratory prototype, where a human operator lifts a load. It is observed that the human machine interaction is stable and the human operator is able to move the load to a desired position by experiencing very little effort.",
 	issn="1573-0409",
 	doi="10.1007/s10846-016-0420-6",
-	url="http://dx.doi.org/10.1007/s10846-016-0420-6",
+	url="https://doi.org/10.1007/s10846-016-0420-6",
 	month=sep
 }
 

--- a/static/js/script001.js
+++ b/static/js/script001.js
@@ -17,7 +17,7 @@ function OpenDOI(DOI) {
 	if (isUrlValid($(DOI).text()))
 		window.open($(DOI).text(), '_blank');
 	else
-		window.open('http://dx.doi.org/' + $(DOI).text(), '_blank');
+		window.open('https://doi.org/' + $(DOI).text(), '_blank');
 }
 
 function OpenURL(URL) {

--- a/themes/skgadi-materializecss/layouts/partials/header.html
+++ b/themes/skgadi-materializecss/layouts/partials/header.html
@@ -210,7 +210,7 @@ function ApplyLayout() {
 }
 
 function OpenDOI(DOI) {
-	window.open('http://dx.doi.org/' + $(DOI).text(), '_blank');
+	window.open('https://doi.org/' + $(DOI).text(), '_blank');
 }
 
 function OpenURL(URL) {

--- a/themes/skgadi/layouts/partials/header.html
+++ b/themes/skgadi/layouts/partials/header.html
@@ -202,7 +202,7 @@ function DisplayItem(id) {
 }
 
 function OpenDOI(DOI) {
-	window.open('http://dx.doi.org/' + $(DOI).text(), '_blank');
+	window.open('https://doi.org/' + $(DOI).text(), '_blank');
 }
 
 function OpenURL(URL) {


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates static DOI links and the code that generates new ones.

Cheers!